### PR TITLE
Ft object names to parameter space

### DIFF
--- a/dinova_bringup/config/vicon_dingo1.yaml
+++ b/dinova_bringup/config/vicon_dingo1.yaml
@@ -1,21 +1,11 @@
 object_names:
   - "dingo1"
-  - "mug1"
-  - "dynamic_object1"
 object_msg_types: # "geometry_msgs/{PoseStamped,TransformStamped,PoseWithCovarianceStamped}"
-  - "geometry_msgs/PoseStamped"
-  - "geometry_msgs/PoseStamped"
   - "geometry_msgs/PoseStamped"
 object_frame_ids:
   - "map"
-  - "map"
-  - "map"
 object_frequency_divider:
-  - 2
-  - 2
   - 2
 object_publish_topics:
   - "/vicon/dingo1"
-  - "/vicon/mug1"
-  - "/vicon/obstacle1"
 

--- a/dinova_bringup/config/vicon_dingo1.yaml
+++ b/dinova_bringup/config/vicon_dingo1.yaml
@@ -1,0 +1,21 @@
+object_names:
+  - "dingo1"
+  - "mug1"
+  - "dynamic_object1"
+object_msg_types: # "geometry_msgs/{PoseStamped,TransformStamped,PoseWithCovarianceStamped}"
+  - "geometry_msgs/PoseStamped"
+  - "geometry_msgs/PoseStamped"
+  - "geometry_msgs/PoseStamped"
+object_frame_ids:
+  - "map"
+  - "map"
+  - "map"
+object_frequency_divider:
+  - 2
+  - 2
+  - 2
+object_publish_topics:
+  - "/vicon/dingo1"
+  - "/vicon/mug1"
+  - "/vicon/obstacle1"
+

--- a/dinova_bringup/config/vicon_dingo2.yaml
+++ b/dinova_bringup/config/vicon_dingo2.yaml
@@ -1,0 +1,16 @@
+object_names:
+  - "dingo2"
+  - "mug1"
+object_msg_types: # "geometry_msgs/{PoseStamped,TransformStamped,PoseWithCovarianceStamped}"
+  - "geometry_msgs/PoseStamped"
+  - "geometry_msgs/PoseStamped"
+object_frame_ids:
+  - "map"
+  - "map"
+object_frequency_divider:
+  - 2
+  - 2
+object_publish_topics:
+  - "/vicon/dingo2"
+  - "/vicon/mug1"
+

--- a/dinova_bringup/launch/dingo.launch
+++ b/dinova_bringup/launch/dingo.launch
@@ -8,13 +8,8 @@
     <arg name="velodyne_frame_id" default="velodyne_base_link"/>
 
      <!-- Vicon -->
-    <arg name="vicon" default="true" /> <!-- Change -->
-    <arg name="object" default="mug1"/>
-    <arg name="object_names" default="[$(env ROBOT_NAME), $(arg object)]"/> <!-- Change -->
-    <arg name="object_msg_types" default="[geometry_msgs/PoseStamped, geometry_msgs/PoseStamped]"/>
-    <arg name="object_frame_ids" default="[map, map]"/>
-    <arg name="object_publish_topics" default="[/vicon/$(env ROBOT_NAME), /vicon/$(arg object)]"/>
-    <arg name="object_frequency_divider" default="[2, 10]"/>
+    <arg name="vicon" default="true" />
+    <arg name="vicon_config_file" default="$(find dinova_bringup)/config/vicon_$(env ROBOT_NAME).yaml"/>
     <param name="/vicon/use_vicon" type="bool" value="$(arg vicon)" />
     <param name="/vicon/dingo_topic" type="string" value="/vicon/$(env ROBOT_NAME)" />
 
@@ -69,13 +64,8 @@
 
     <!-- Vicon Nodes -->
     <group if="$(arg vicon)">
-        <include file="$(find dinova_bringup)/launch/vicon.launch">
-            <arg name="object_names"                    value="$(arg object_names)"/>
-            <arg name="object_msg_types"                value="$(arg object_msg_types)"/>
-            <arg name="object_frame_ids"                value="$(arg object_frame_ids)"/>
-            <arg name="object_publish_topics"           value="$(arg object_publish_topics)"/>
-            <arg name="object_frequency_divider"        value="$(arg object_frequency_divider)"/>
-        </include>
+        <rosparam ns="vicon/object_specific" command="load" file="$(arg vicon_config_file)"/>
+        <include file="$(find dinova_bringup)/launch/vicon.launch"/>
         <node pkg="tf" type="static_transform_publisher" name="$(env ROBOT_NAME)_static_tf" args="0 0 0 0 0 0 $(env ROBOT_NAME) base_link 0.1" />
     </group>
 

--- a/dinova_bringup/launch/dinova.launch
+++ b/dinova_bringup/launch/dinova.launch
@@ -9,17 +9,10 @@
     <arg name="dingo_real_urdf" default="true" />
     <arg name="load_gripper" default="true" />
 
-    <!-- Vicon -->
-    <arg name="vicon" default="true" /> <!-- Change -->
-    <arg name="object" default="mug1"/>
-    <arg name="object_names" default="[$(env ROBOT_NAME), $(arg object)]"/> <!-- Change -->
-    <arg name="object_msg_types" default="[geometry_msgs/PoseStamped, geometry_msgs/PoseStamped]"/>
-    <arg name="object_frame_ids" default="[map, map]"/>
-    <arg name="object_publish_topics" default="[/vicon/$(env ROBOT_NAME), /vicon/$(arg object)]"/>
-    <arg name="object_frequency_divider" default="[2, 10]"/>
+     <!-- Vicon -->
+    <arg name="vicon" default="true" />
+    <arg name="vicon_config_file" default="$(find dinova_bringup)/config/vicon_$(env ROBOT_NAME).yaml"/>
     <param name="/vicon/use_vicon" type="bool" value="$(arg vicon)" />
-
-    <rosparam param="/object_names" subst_value="True">$(arg object_names)</rosparam> 
     <param name="/vicon/dingo_topic" type="string" value="/vicon/$(env ROBOT_NAME)" />
 
     <!-- Robot model -->
@@ -76,13 +69,8 @@
 
     <!-- Vicon nodes -->
     <group if="$(arg vicon)">
-        <include file="$(find dinova_bringup)/launch/vicon.launch">
-            <arg name="object_names"                    value="$(arg object_names)"/>
-            <arg name="object_msg_types"                value="$(arg object_msg_types)"/>
-            <arg name="object_frame_ids"                value="$(arg object_frame_ids)"/>
-            <arg name="object_publish_topics"           value="$(arg object_publish_topics)"/>
-            <arg name="object_frequency_divider"        value="$(arg object_frequency_divider)"/>
-        </include>
+        <rosparam ns="vicon/object_specific" command="load" file="$(arg vicon_config_file)"/>
+        <include file="$(find dinova_bringup)/launch/vicon.launch"/>
         <node pkg="tf" type="static_transform_publisher" name="$(env ROBOT_NAME)_static_tf" args="0 0 0 0 0 0 $(env ROBOT_NAME) base_link 0.1" />
     
     </group>

--- a/dinova_bringup/launch/kinova.launch
+++ b/dinova_bringup/launch/kinova.launch
@@ -1,12 +1,5 @@
 <?xml version="1.0"?>
 <launch>
-     <!-- Vicon -->
-    <arg name="vicon" default="true" />
-    <arg name="object_names" default="[dingo1, mug1]"/>
-    <arg name="object_msg_types" default="[geometry_msgs/PoseStamped, geometry_msgs/PoseStamped]"/>
-    <arg name="object_frame_ids" default="[map, map]"/>
-    <arg name="object_publish_topics" default="[/vicon/dingo1, /vicon/mug1]"/>
-    <arg name="object_frequency_divider" default="[2, 10]"/>
 
 
     <!-- Robot model -->
@@ -18,19 +11,20 @@
     <!-- Teleoperation via joystick and rviz interactive markers -->
     <include file="$(find dingo_control)/launch/teleop.launch" />
 
+     <!-- Vicon -->
+    <arg name="vicon" default="true" />
+    <arg name="vicon_config_file" default="$(find dinova_bringup)/config/vicon_$(env ROBOT_NAME).yaml"/>
+    <param name="/vicon/use_vicon" type="bool" value="$(arg vicon)" />
+    <param name="/vicon/dingo_topic" type="string" value="/vicon/$(env ROBOT_NAME)" />
+
 
     <rosparam command="load" file="$(find dinova_control)/config/config.yaml" />
     <node name="kinova_driver" pkg="dinova_control" type="kinova_driver.py" args="" output="screen"/>
 
     <!-- Vicon Nodes -->
     <!-- <group if="$(eval arg('vicon') == 'true')">
-        <include file="$(find dinova_bringup)/launch/vicon.launch">
-            <arg name="object_names"                    value="$(arg object_names)"/>
-            <arg name="object_msg_types"                value="$(arg object_msg_types)"/>
-            <arg name="object_frame_ids"                value="$(arg object_frame_ids)"/>
-            <arg name="object_publish_topics"           value="$(arg object_publish_topics)"/>
-            <arg name="object_frequency_divider"        value="$(arg object_frequency_divider)"/>
-        </include>
+        <rosparam ns="vicon/object_specific" command="load" file="$(arg vicon_config_file)"/>
+        <include file="$(find dinova_bringup)/launch/vicon.launch"/>
     </group> -->
 
 </launch>

--- a/dinova_bringup/launch/vicon.launch
+++ b/dinova_bringup/launch/vicon.launch
@@ -22,14 +22,6 @@
 <!-- If we want to specify each object seperately and if we only want to publish specific objects-->
 <arg name="only_use_object_specific" default="true"/>
 
-<arg name="object_names" default="[dingo1, mug1]"/>
-<arg name="object_msg_types" default="[geometry_msgs/PoseStamped, geometry_msgs/PoseStamped]"/>
-<arg name="object_frame_ids" default="[map, map]"/>
-<arg name="object_publish_topics" default="[/vicon/dingo1, /vicon/mug1]"/>
-<arg name="object_frequency_divider" default="[2, 10]"/>
-
-
-
 
 <node pkg="vicon_bridge" type="vicon_bridge" name="vicon" output="screen" >
   <param name="stream_mode" value="ServerPush"/>
@@ -40,11 +32,6 @@
   <param name="publish_transform" value="$(arg publish_tf)"/>
   <param name="reset_z_axis" value="$(arg reset_z_axis)"/>
   <param name="only_use_object_specific" value="$(arg only_use_object_specific)"/>
-  <rosparam param="object_specific/object_names" subst_value="True">$(arg object_names)</rosparam>
-  <rosparam param="object_specific/object_msg_types" subst_value="True">$(arg object_msg_types)</rosparam>
-  <rosparam param="object_specific/object_frame_ids" subst_value="True">$(arg object_frame_ids)</rosparam>
-  <rosparam param="object_specific/object_publish_topics" subst_value="True">$(arg object_publish_topics)</rosparam>
-  <rosparam param="object_specific/object_frequency_divider" subst_value="True">$(arg object_frequency_divider)</rosparam>
 </node>
     
 </launch>


### PR DESCRIPTION
Moves object_specifics from the launch file to a dedicated configuration file.
This allows to have different setups depending on the use case without changing the launch file.

Also, object_names will no be published in `/vicon/object_specific/object_names`.