### PR TITLE
fix[velocities]: Addresses #21 by changing the vicon callback.

### DIFF
--- a/dinova_control/scripts/dingo_state_publisher.py
+++ b/dinova_control/scripts/dingo_state_publisher.py
@@ -7,6 +7,7 @@ from threading import Thread
 from nav_msgs.msg import Odometry
 import tf
 from geometry_msgs.msg import PoseStamped, Pose
+import numpy as np
 
 class DingoStatePublisher():
     def __init__(self) -> None:
@@ -29,24 +30,30 @@ class DingoStatePublisher():
         self.dingo_vicon_state = self.init_dingo_joint_state_var()
     
     def callback_vicon(self, msg):
-        js_msg = JointState()
-        js_msg.header.stamp = rospy.Time.now()
-        # Dingo
-        js_msg.name.append("omni_joint_x")
-        js_msg.position.append(msg.pose.position.x)
-        js_msg.velocity.append(self.dingo_base_state.velocity[0])
-        js_msg.effort.append(0.0)
-         # omni_joint_y
-        js_msg.name.append("omni_joint_y")
-        js_msg.position.append(msg.pose.position.y)
-        js_msg.velocity.append(self.dingo_base_state.velocity[1])
-        js_msg.effort.append(0.0)
-        # omni_joint_theta
-        js_msg.name.append("omni_joint_theta")
         theta = tf.transformations.euler_from_quaternion([msg.pose.orientation.x,
                                                           msg.pose.orientation.y,
                                                           msg.pose.orientation.z,
                                                           msg.pose.orientation.w])[2]
+        js_msg = JointState()
+        js_msg.header.stamp = rospy.Time.now()
+        velocities_robot_frame = self.dingo_base_state.velocity[0:2]
+        rotation = np.array([
+            [np.cos(theta), -np.sin(theta)], 
+            [np.sin(theta), np.cos(theta)], 
+        ])
+        velocities_vicon_frame = np.dot(rotation, velocities_robot_frame)
+        # Dingo
+        js_msg.name.append("omni_joint_x")
+        js_msg.position.append(msg.pose.position.x)
+        js_msg.velocity.append(velocities_vicon_frame[0])
+        js_msg.effort.append(0.0)
+         # omni_joint_y
+        js_msg.name.append("omni_joint_y")
+        js_msg.position.append(msg.pose.position.y)
+        js_msg.velocity.append(velocities_vicon_frame[1])
+        js_msg.effort.append(0.0)
+        # omni_joint_theta
+        js_msg.name.append("omni_joint_theta")
     
         js_msg.position.append(theta)
         js_msg.velocity.append(self.dingo_base_state.velocity[2])


### PR DESCRIPTION
In case the vicon system is used, we want the velocities to be in the vicons map frame, just like the positions.
That solves this issue, see #21.