### PR TITLE
ft initial joint configuration for velocity mode

### DIFF
--- a/dinova_gazebo/config/gazebo_controllers.yaml
+++ b/dinova_gazebo/config/gazebo_controllers.yaml
@@ -28,7 +28,7 @@ joints_position_controller:
         - joint_5
         - joint_6
 
-kinova:
+joints_velocity_controller:
     type: velocity_controllers/JointGroupVelocityController
     joints:
         - joint_1
@@ -37,6 +37,7 @@ kinova:
         - joint_4
         - joint_5
         - joint_6
+        
 
 gripper_position_controller:
     type: position_controllers/GripperActionController
@@ -49,75 +50,3 @@ gazebo_ros_control:
         right_finger_tip_joint: {p: 1.0, i: 0.0, d: 0.0} 
         left_finger_bottom_joint: {p: 10.0, i: 0.0, d: 0.0} 
         left_finger_tip_joint: {p: 1.0, i: 0.0, d: 0.0}
-
-# joint_1_position_controller:
-#     joint: joint_1
-#     pid:
-#         p: 3000.0
-#         i: 0.0
-#         d: 2.0
-#     type: effort_controllers/JointPositionController
-
-# joint_2_position_controller:
-#     joint: joint_2
-#     pid:
-#         p: 50000.0
-#         i: 0.0
-#         d: 0.0
-#     type: effort_controllers/JointPositionController
-
-# joint_3_position_controller:
-#     joint: joint_3
-#     pid:
-#         p: 50000.0
-#         i: 0.0
-#         d: 0.0
-#     type: effort_controllers/JointPositionController
-
-# joint_4_position_controller:
-#     joint: joint_4
-#     pid:
-#         p: 750.0
-#         i: 0.0
-#         d: 0.2
-#     type: effort_controllers/JointPositionController
-
-# joint_5_position_controller:
-#     joint: joint_5
-#     pid:
-#         p: 5000.0
-#         i: 0.0
-#         d: 1.0
-#     type: effort_controllers/JointPositionController
-
-# joint_6_position_controller:
-#     joint: joint_6
-#     pid:
-#         p: 100.0
-#         i: 0.0
-#         d: 0.0
-#     type: effort_controllers/JointPositionController
-
-# TrajectoryController that works differently than JointGroupPositionController
-# joints_position_controller:
-#     type: effort_controllers/JointTrajectoryController
-#     joints:
-#         - joint_1
-#         - joint_2
-#         - joint_3
-#         - joint_4
-#         - joint_5
-#         - joint_6
-#     constraints:
-#         goal_time: 1.0
-#         stopped_velocity_tolerance: 0.5
-#     stop_trajectory_duration: 1.0
-#     state_publish_rate:  1000
-#     action_monitor_rate: 1000
-#     gains:
-#         joint_1: {p: 3000.0, i: 0.0, d: 2.0, i_clamp_min: -100.0, i_clamp_max: 100.0}
-#         joint_2: {p: 50000.0, i: 0.0, d: 0.0, i_clamp_min: -5.0, i_clamp_max: 5.0}
-#         joint_3: {p: 50000.0, i: 0.0, d: 0.0, i_clamp_min: -1.0, i_clamp_max: 1.0}
-#         joint_4: {p: 750.0, i: 0.0, d: 0.2, i_clamp_min: -1.0, i_clamp_max: 1.0}
-#         joint_5: {p: 5000.0, i: 0.0, d: 1.0, i_clamp_min: -1.0, i_clamp_max: 1.0}
-#         joint_6: {p: 100.0, i: 0.0, d: 0.0, i_clamp_min: -0.1, i_clamp_max: 0.1}

--- a/dinova_gazebo/launch/dingo.launch
+++ b/dinova_gazebo/launch/dingo.launch
@@ -11,7 +11,12 @@
     <arg name="mode" default="velocity" />  
     <arg name="rviz" default="false" />
     <arg name="dyn_obstacle" default="false" />
-
+    <arg name="initial_joint_positions"
+       doc="Initial joint configuration of the panda. Specify as a list of name/value pairs in form of '-J [name-of-joint] [value-in-rad]'. Default is a 90 degree bend in the elbow"
+       default="-J $(arg dingo_id)omni_joint_x 1.0
+                -J $(arg dingo_id)omni_joint_y 0.0
+                -J $(arg dingo_id)omni_joint_theta 0.0" 
+                />
 
     <!-- Load urdf -->
     <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find dinova_gazebo)/urdf/dingo_gazebo.xacro'
@@ -42,7 +47,7 @@
 
     <!-- Spawn model in Gazebo -->
     <node name="model_spawner" pkg="gazebo_ros" type="spawn_model" respawn="false"
-          output="screen" args="-param robot_description -urdf -model dingo_omni"/>
+          output="screen" args="-param robot_description -urdf -model dingo_omni $(arg initial_joint_positions)"/>
 
     <!-- Load joint controller configurations from YAML file to parameter server -->
     <rosparam file="$(find dinova_gazebo)/config/gazebo_controllers.yaml" command="load"/>

--- a/dinova_gazebo/launch/dinova.launch
+++ b/dinova_gazebo/launch/dinova.launch
@@ -20,8 +20,8 @@
                 -J $(arg dingo_id)omni_joint_theta 0.0
                 -J $(arg dingo_id)joint_1 0.0
                 -J $(arg dingo_id)joint_2 0.0
-                -J $(arg dingo_id)joint_3 1.57
-                -J $(arg dingo_id)joint_4 1.57
+                -J $(arg dingo_id)joint_3 0.0
+                -J $(arg dingo_id)joint_4 1.7
                 -J $(arg dingo_id)joint_5 1.57
                 -J $(arg dingo_id)joint_6 -1.57
                 -J $(arg dingo_id)right_finger_bottom_joint 0.001" 

--- a/dinova_gazebo/launch/dinova.launch
+++ b/dinova_gazebo/launch/dinova.launch
@@ -2,7 +2,7 @@
 <launch>
     <!-- Argumnets for Kinova robot -->
     <arg name="dingo_id" default="" />
-    <arg name="mode" default="position" />  
+    <arg name="mode" default="velocity" />  
     <arg name="load_gripper" default="true" />
     <arg name="rviz" default="false" />
 
@@ -13,6 +13,19 @@
     <arg name="headless" default="false"/>
     <arg name="debug" default="false"/>
     <arg name="dyn_obstacle" default="false" />
+    <arg name="initial_joint_positions"
+       doc="Initial joint configuration of the panda. Specify as a list of name/value pairs in form of '-J [name-of-joint] [value-in-rad]'. Default is a 90 degree bend in the elbow"
+       default="-J $(arg dingo_id)omni_joint_x 0.0
+                -J $(arg dingo_id)omni_joint_y 0.0
+                -J $(arg dingo_id)omni_joint_theta 0.0
+                -J $(arg dingo_id)joint_1 0.0
+                -J $(arg dingo_id)joint_2 0.0
+                -J $(arg dingo_id)joint_3 1.57
+                -J $(arg dingo_id)joint_4 1.57
+                -J $(arg dingo_id)joint_5 1.57
+                -J $(arg dingo_id)joint_6 -1.57
+                -J $(arg dingo_id)right_finger_bottom_joint 0.001" 
+                />
 
 
     <!-- Load urdf -->
@@ -45,7 +58,7 @@
 
     <!-- Spawn model in Gazebo -->
     <node name="model_spawner" pkg="gazebo_ros" type="spawn_model" respawn="false"
-          output="screen" args="-param robot_description -urdf -model dingo_omni"/>
+          output="screen" args="-param robot_description -urdf -model dinova $(arg initial_joint_positions)"/>
 
     <!-- Load joint controller configurations from YAML file to parameter server -->
     <rosparam file="$(find dinova_gazebo)/config/gazebo_controllers.yaml" command="load"/>
@@ -63,7 +76,7 @@
                 output="screen" args="
                     joint_state_controller
                     omnidrive_velocity_controller
-                    kinova"/>    
+                    joints_velocity_controller"/>    
     </group>
     <!-- load the gripper controller -->
     <group if="$(eval arg('load_gripper'))">

--- a/dinova_gazebo/launch/kinova.launch
+++ b/dinova_gazebo/launch/kinova.launch
@@ -2,7 +2,7 @@
 <launch>
     <!-- Argumnets for Kinova robot -->
     <arg name="dingo_id" default="" />
-    <arg name="mode" default="position" />  
+    <arg name="mode" default="velocity" />  
     <arg name="load_gripper" default="true" />
     <arg name="rviz" default="false" />
     <arg name="dyn_obstacle" default="false" />
@@ -13,6 +13,17 @@
     <arg name="gui" default="true"/>
     <arg name="headless" default="false"/>
     <arg name="debug" default="false"/>
+    
+    <arg name="initial_joint_positions"
+       doc="Initial joint configuration of the panda. Specify as a list of name/value pairs in form of '-J [name-of-joint] [value-in-rad]'. Default is a 90 degree bend in the elbow"
+       default="-J $(arg dingo_id)joint_1 0.0
+                -J $(arg dingo_id)joint_2 0.0
+                -J $(arg dingo_id)joint_3 1.57
+                -J $(arg dingo_id)joint_4 1.57
+                -J $(arg dingo_id)joint_5 1.57
+                -J $(arg dingo_id)joint_6 -1.57
+                -J $(arg dingo_id)right_finger_bottom_joint 0.001" 
+                />
 
 
     <!-- Load urdf -->
@@ -45,7 +56,7 @@
 
     <!-- Spawn model in Gazebo -->
     <node name="model_spawner" pkg="gazebo_ros" type="spawn_model" respawn="false"
-          output="screen" args="-param robot_description -urdf -model dingo_omni"/>
+          output="screen" args="-param robot_description -urdf -model kinova $(arg initial_joint_positions)"/>
 
     <!-- Load joint controller configurations from YAML file to parameter server -->
     <rosparam file="$(find dinova_gazebo)/config/gazebo_controllers.yaml" command="load"/>
@@ -61,7 +72,7 @@
         <node name="controllers_spawner" pkg="controller_manager" type="spawner" respawn="false"
                 output="screen" args="
                     joint_state_controller
-                    kinova"/>    
+                    joints_velocity_controller"/>    
     </group>
     <!-- load the gripper controller -->
     <group if="$(eval arg('load_gripper'))">


### PR DESCRIPTION
Feature for Gazebo -> Argument for setting the initial joint configuration. It only works in the velocity control mode. I guess that the position control mode overwrites the home configuration.