### PR TITLE
Fix issue dinova motion 37

### DIFF
--- a/dinova_gazebo/launch/dinova.launch
+++ b/dinova_gazebo/launch/dinova.launch
@@ -59,6 +59,7 @@
     <!-- Spawn model in Gazebo -->
     <node name="model_spawner" pkg="gazebo_ros" type="spawn_model" respawn="false"
           output="screen" args="-param robot_description -urdf -model dinova $(arg initial_joint_positions)"/>
+    <param name="/$(env ROBOT_NAME)/dinova_fk_description" textfile="$(find dinova_control)/config/dingo1_dinova.urdf"/>
 
     <!-- Load joint controller configurations from YAML file to parameter server -->
     <rosparam file="$(find dinova_gazebo)/config/gazebo_controllers.yaml" command="load"/>


### PR DESCRIPTION
This fixes the issue raised in INTERACT-tud-amr/dinova_motion#37 by including the following line in the simulator launch file (dinova_gazebo/launch/dinova.launch):
    <param name="/$(env ROBOT_NAME)/dinova_fk_description" textfile="$(find dinova_control)/config/dingo1_dinova.urdf"/>
    
For the real robot this is done in a launch file from the bring_up package. However, since this is not used in the simulator case, I added this here instead. Only two differences remain:
1. I explicitly set the parameter scope, i.e., I set "/$(env ROBOT_NAME)/parameter", instead of the bring_up's way of relatively setting, i.e., merely setting "parameter".
2. I hardcode "dingo1_dinova.urdf", instead of using "$(env ROBOT_NAME)_dinova.urdf", because the robot name in the simulator is dinova, and dinova_dinova.urdf does not exist/make sense, but it should be equivalent to "dingo1_dinova.urdf" (also, there is no difference between dingo1_dinova.urdf and dingo2_dinova.urdf)


Note, one annoying thing is that ROBOT_NAME is not necessarily set when someone tries to launch the simulator, so it would probably make sense to already declare the robot_name in the launch file, because there is only one. But I could not find how this is usually done, and I did not want to introduce an inconsistent new way of doing this.
